### PR TITLE
Modify EvaluateTemplate to use scope nullable

### DIFF
--- a/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
+++ b/libraries/Microsoft.Bot.Builder.LanguageGeneration/TemplateEngine.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <param name="scope">The state visible in the evaluation.</param>
         /// <param name="methodBinder">Optional methodBinder to extend or override functions.</param>
         /// <returns>Evaluate result.</returns>
-        public string EvaluateTemplate(string templateName, object scope, IGetMethod methodBinder = null)
+        public string EvaluateTemplate(string templateName, object scope = null, IGetMethod methodBinder = null)
         {
             var evaluator = new Evaluator(Templates, methodBinder);
             return evaluator.EvaluateTemplate(templateName, scope);
@@ -124,7 +124,7 @@ namespace Microsoft.Bot.Builder.LanguageGeneration
         /// <param name="scope">scope object or JToken.</param>
         /// <param name="methodBinder">input method.</param>
         /// <returns>Evaluate result.</returns>
-        public string Evaluate(string inlineStr, object scope, IGetMethod methodBinder = null)
+        public string Evaluate(string inlineStr, object scope = null, IGetMethod methodBinder = null)
         {
             // wrap inline string with "# name and -" to align the evaluation process
             var fakeTemplateId = "__temp__";

--- a/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
+++ b/tests/Microsoft.Bot.Builder.LanguageGeneration.Tests/TemplateEngineTest.cs
@@ -32,6 +32,18 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         }
 
         [TestMethod]
+        public void TestBasicTemplate()
+        {
+            var engine = TemplateEngine.FromFiles(GetExampleFilePath("2.lg"));
+
+            var evaled = engine.EvaluateTemplate("wPhrase");
+            var options = new List<string> { "Hi", "Hello", "Hiya " };
+
+            Assert.IsTrue(options.Contains(evaled), $"The result `{evaled}` is not in those options [{string.Join(",", options)}]");
+        }
+
+
+        [TestMethod]
         public void TestBasicTemplateReference()
         {
             var engine = TemplateEngine.FromFiles(GetExampleFilePath("3.lg"));
@@ -164,6 +176,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestBasicInlineTemplate()
         {
             var emptyEngine = TemplateEngine.FromText("");
+            Assert.AreEqual(emptyEngine.Evaluate("Hi"), "Hi");
             Assert.AreEqual(emptyEngine.Evaluate("Hi", null), "Hi");
             Assert.AreEqual(emptyEngine.Evaluate("Hi {name}", new { name = "DL" }), "Hi DL");
             Assert.AreEqual(emptyEngine.Evaluate("Hi {name.FirstName}{name.LastName}", new { name = new { FirstName = "D", LastName = "L" } }), "Hi DL");
@@ -177,6 +190,7 @@ namespace Microsoft.Bot.Builder.AI.LanguageGeneration.Tests
         public void TestInlineTemplateWithTemplateFile()
         {
             var emptyEngine = TemplateEngine.FromFiles(GetExampleFilePath("8.lg"));
+            Assert.AreEqual(emptyEngine.Evaluate("Hi"), "Hi");
             Assert.AreEqual(emptyEngine.Evaluate("Hi", null), "Hi");
             Assert.AreEqual(emptyEngine.Evaluate("Hi {name}", new { name = "DL" }), "Hi DL");
             Assert.AreEqual(emptyEngine.Evaluate("Hi {name.FirstName}{name.LastName}", new { name = new { FirstName = "D", LastName = "L" } }), "Hi DL");


### PR DESCRIPTION
I think it is a good option to put the scope nullable, with this we don't force to pass a null by parameter.

I have also added a new test case to verify that everything is correct without passing the scope by parameter.

Thanks,